### PR TITLE
Simplified command

### DIFF
--- a/src/main/java/io/github/icrazyblaze/modlistpaste/command/CopyCommand.java
+++ b/src/main/java/io/github/icrazyblaze/modlistpaste/command/CopyCommand.java
@@ -4,6 +4,7 @@ import com.mojang.brigadier.Command;
 import com.mojang.brigadier.arguments.BoolArgumentType;
 import com.mojang.brigadier.builder.ArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
+
 import io.github.icrazyblaze.modlistpaste.ModListToClipboard;
 import net.minecraft.command.CommandSource;
 import net.minecraft.command.Commands;
@@ -19,6 +20,11 @@ public class CopyCommand implements Command<CommandSource> {
     public static ArgumentBuilder<CommandSource, ?> register() {
         return Commands.literal("copy")
                 .requires(cs -> cs.hasPermission(0))
+                .executes(c -> {
+                	ModListToClipboard.copyModList(false);
+                    c.getSource().sendSuccess(new StringTextComponent("Copied text to clipboard!"), false);
+                	return SINGLE_SUCCESS;
+                })
                 .then(Commands.argument("alphabetical", BoolArgumentType.bool())
                 .executes(CMD));
     }


### PR DESCRIPTION
People were complaining the command didn't work. Likely because the mod page shows all you have to run is "/modlist copy" or save and in-game they didn't see that you had to fill the last arg. We assume non-alphabetical here if the argument is ignored.